### PR TITLE
Remove js code from line 73 that causes an error in onLoad

### DIFF
--- a/Client/templates/layouts/main.php
+++ b/Client/templates/layouts/main.php
@@ -70,7 +70,7 @@
         </div>
     </nav>
 
-<body onload="document.getElementById('defaultOpen').click();">
+<body onload="">
 
     <div class='container'>
         <?= \Rapid\Renderer::VIEW_PLACEHOLDER ?>


### PR DESCRIPTION
This fixes an undefined reference error that occurs on every page when the onload event is triggered. This error prevents an automated test toolkit from loading the project.
Test tool can be found here https://github.com/MaxDKIT/ArcAutomatedGuiTesting